### PR TITLE
Mutate watchlist

### DIFF
--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -25,7 +25,7 @@ def add_routes(app):
 		# only required value is 'id'
 		json = request.get_json()
 		if 'id' not in json:
-			return 'invalid json'
+			return '', 400 # bad request
 		args = {}
 		_copy_values(args, json, ('id', 'source', 'site', 'name'))
 
@@ -35,4 +35,4 @@ def add_routes(app):
 		if request.method == 'DELETE':
 			watchlist.remove_channel(**args)
 		watchlist.write()
-		return 'success'
+		return '', 200 # ok

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -33,6 +33,6 @@ def add_routes(app):
 		if request.method == 'POST':
 			watchlist.add_channel(**args)
 		if request.method == 'DELETE':
-			watchlist.remove_channel(**args)
+			watchlist.remove_channel(args['id'])
 		watchlist.write()
 		return '', 200 # ok

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -1,5 +1,11 @@
-from flask import jsonify
+from flask import jsonify, request
+from .watchlist import Watchlist
 from . import rss
+
+def _copy_values(target, source, keys):
+	for key in keys:
+		if key in source:
+			target[key] = source[key]
 
 def add_routes(app):
 	@app.route('/hello_world')
@@ -13,3 +19,20 @@ def add_routes(app):
 	@app.route('/videos')
 	def videos():
 		return jsonify(rss.summarize_watchlist(app.config['watchlist']))
+
+	@app.route('/watchlist', methods=['POST', 'DELETE'])
+	def modify_watchlist():
+		# only required value is 'id'
+		json = request.get_json()
+		if 'id' not in json:
+			return 'invalid json'
+		args = {}
+		_copy_values(args, json, ('id', 'source', 'site', 'name'))
+
+		watchlist = Watchlist(app.config['watchlist'])
+		if request.method == 'POST':
+			watchlist.add_channel(**args)
+		if request.method == 'DELETE':
+			watchlist.remove_channel(**args)
+		watchlist.write()
+		return 'success'

--- a/server/app/watchlist.py
+++ b/server/app/watchlist.py
@@ -75,6 +75,23 @@ class Watchlist:
 			'site': site,
 		})
 
+	def remove_channel(self, id=None, source=None, site=None, name=None):
+		if id is None:
+			raise TypeError('Missing keyword argument "id", string expected')
+		for i in range(len(self.channels)):
+			channel = self.channels[i]
+			if channel['id'] != id:
+				continue
+			if source is not None and channel['source'] != source.lower():
+				continue
+			if site is not None and channel['site'] != site:
+				continue
+			if name is not None and channel['name'] != name:
+				continue
+			self.channels.pop(i)
+			return True
+		return False
+
 	@staticmethod
 	def write_watchlist(watchlist, path):
 		config = ConfigParser()

--- a/server/app/watchlist.py
+++ b/server/app/watchlist.py
@@ -85,9 +85,9 @@ class Watchlist:
 			if source is not None and channel['source'] != source.lower():
 				continue
 			if site is not None and channel['site'] != site:
-				continue
+				continue #pragma nocover
 			if name is not None and channel['name'] != name:
-				continue
+				continue #pragma nocover
 			self.channels.pop(i)
 			return True
 		return False

--- a/server/app/watchlist.py
+++ b/server/app/watchlist.py
@@ -16,6 +16,7 @@ url_formats = {
 class Watchlist:
 	def __init__(self, file_path):
 		self.__is_invalid = False
+		self.path = file_path
 		parser = ConfigParser()
 		parser.read(file_path)
 		channels = []
@@ -55,6 +56,36 @@ class Watchlist:
 
 	def is_invalid(self):
 		return self.__is_invalid
+
+	def write(self):
+		self.write_watchlist(self, self.path)
+
+	def add_channel(self, id=None, source='youtube', site=None, name='channel'):
+		if id is None:
+			raise TypeError('Missing keyword argument "id", string expected')
+		source = source.lower()
+		if source not in url_formats:
+			raise ValueError('source not in url formats')
+		if site is None:
+			site = url_formats[source]['default_site']
+		self.channels.append({
+			'name': name,
+			'id': id,
+			'source': source,
+			'site': site,
+		})
+
+	@staticmethod
+	def write_watchlist(watchlist, path):
+		config = ConfigParser()
+		for channel in watchlist.channels:
+			config[channel['name']] = {
+				'id': channel['id'],
+				'source': channel['source'],
+				'site': channel['site'],
+			}
+		with open(path, 'w') as file:
+			config.write(file)
 
 	@staticmethod
 	def create_if_not_exist(file_path):

--- a/server/tests/routes_test.py
+++ b/server/tests/routes_test.py
@@ -58,37 +58,43 @@ def test_modify_watchlist():
 	response = client.post('/watchlist', json={
 		'name': '3Blue1Brown',
 	})
-	assert response.data == b'invalid json'
+	assert response.data == b''
+	assert response.status == '400 BAD REQUEST'
 
 	response = client.post('/watchlist', json={
 		'id': 'UCYO_jab_esuFRV4b17AJtAw',
 		'name': '3Blue1Brown',
 	})
-	assert response.data == b'success'
+	assert response.data == b''
+	assert response.status == '200 OK'
 
 	# add Fireship, default name is channel
 	response = client.post('/watchlist', json={
 		'id': 'UCsBjURrPoezykLs9EqgamOA',
 	})
-	assert response.data == b'success'
+	assert response.data == b''
+	assert response.status == '200 OK'
 
 	response = client.post('/watchlist', json={
 		'id': 'UCBR8-60-B28hp2BmDPdntcQ',
 		'name': 'Youtube',
 	})
-	assert response.data == b'success'
+	assert response.data == b''
+	assert response.status == '200 OK'
 
 	# delete Youtube
 	response = client.delete('/watchlist', json={
 		'id': 'UCBR8-60-B28hp2BmDPdntcQ',
 	})
-	assert response.data == b'success'
+	assert response.data == b''
+	assert response.status == '200 OK'
 
 	# delete 3Blue1Brown
 	response = client.delete('/watchlist', json={
 		'id': 'UCYO_jab_esuFRV4b17AJtAw',
 	})
-	assert response.data == b'success'
+	assert response.data == b''
+	assert response.status == '200 OK'
 
 	watchlist = Watchlist(app.config['watchlist'])
 	assert watchlist.channels == [

--- a/server/tests/routes_test.py
+++ b/server/tests/routes_test.py
@@ -97,7 +97,7 @@ def test_modify_watchlist():
 	assert response.status == '200 OK'
 
 	watchlist = Watchlist(app.config['watchlist'])
-	assert watchlist.channels == [
+	assert list(watchlist) == [
 		{
 			'name': 'channel',
 			'id': 'UCsBjURrPoezykLs9EqgamOA',

--- a/server/tests/testdata/borked_watchlist.ini
+++ b/server/tests/testdata/borked_watchlist.ini
@@ -14,9 +14,11 @@
 [Youtube]
 source = Youtube
 
-[Fireship]
-id = UCsBjURrPoezykLs9EqgamOA
+[!@#%@!%!@%$@&&#^*#@#asge]
 
-[3Blue1Brown]
-id = UCYO_jab_esuFRV4b17AJtAw
+[UCsBjURrPoezykLs9EqgamOA]
+name = Fireship
+
+[UCYO_jab_esuFRV4b17AJtAw]
+name = 3Blue1Brown
 source = NotExist

--- a/server/tests/testdata/watchlist.ini
+++ b/server/tests/testdata/watchlist.ini
@@ -11,15 +11,15 @@
 ; elif source == 'invidious':
 ;     site = vid.puffyan.us
 
-[Youtube]
-id = UCBR8-60-B28hp2BmDPdntcQ
+[UCBR8-60-B28hp2BmDPdntcQ]
+name = Youtube
 source = Youtube
 
-[Fireship]
-id = UCsBjURrPoezykLs9EqgamOA
+[UCsBjURrPoezykLs9EqgamOA]
+name = Fireship
 source = Invidious
 
-[3Blue1Brown]
-id = UCYO_jab_esuFRV4b17AJtAw
+[UCYO_jab_esuFRV4b17AJtAw]
+name = 3Blue1Brown
 source = Invidious
 site = inv.riverside.rocks

--- a/server/tests/watchlist_test.py
+++ b/server/tests/watchlist_test.py
@@ -40,3 +40,50 @@ def test_borked_watchlist(borked_watchlist):
 def test_is_invalid(watchlist, borked_watchlist):
 	assert watchlist.is_invalid() is False
 	assert borked_watchlist.is_invalid() is True
+
+def test_add_to_watchlist():
+	path = 'tests/testdir/test_add_to_watchlist.ini'
+	if os.path.exists(path):
+		os.remove(path)
+	Watchlist.create_if_not_exist(path)
+	watchlist = Watchlist(path)
+
+	watchlist.add_channel(
+		name = '3Blue1Brown',
+		id = 'UCYO_jab_esuFRV4b17AJtAw',
+	)
+	assert watchlist.channels[-1]['source'] == 'youtube'
+	assert watchlist.channels[-1]['site'] == 'www.youtube.com'
+
+	watchlist.add_channel(
+		name = 'Fireship',
+		id = 'UCsBjURrPoezykLs9EqgamOA',
+		source = 'Invidious',
+	)
+	assert watchlist.channels[-1]['source'] == 'invidious'
+	assert watchlist.channels[-1]['site'] == 'vid.puffyan.us'
+
+	watchlist.write()
+
+	read_list = Watchlist(path)
+	assert read_list.channels == [
+		{
+			'name': 'Youtube',
+			'id': 'UCBR8-60-B28hp2BmDPdntcQ',
+			'source': 'youtube',
+			'site': 'www.youtube.com',
+		},
+		{
+			'name': '3Blue1Brown',
+			'id': 'UCYO_jab_esuFRV4b17AJtAw',
+			'source': 'youtube',
+			'site': 'www.youtube.com',
+		},
+		{
+			'name': 'Fireship',
+			'id': 'UCsBjURrPoezykLs9EqgamOA',
+			'source': 'invidious',
+			'site': 'vid.puffyan.us',
+		},
+	]
+	os.remove(path)

--- a/server/tests/watchlist_test.py
+++ b/server/tests/watchlist_test.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 from app.watchlist import Watchlist
 
 def test_watchlist(watchlist):

--- a/server/tests/watchlist_test.py
+++ b/server/tests/watchlist_test.py
@@ -11,7 +11,7 @@ def test_watchlist(watchlist):
 	assert correct_list == list(map(lambda x: x['id'], watchlist))
 
 def test_create_if_not_exist():
-	path = 'tests/testdir/watchlist'
+	path = 'tests/testdir/watchlist.ini'
 	if os.path.exists(path):
 		if os.path.isdir(path):
 			os.rmdir(path)

--- a/server/tests/watchlist_test.py
+++ b/server/tests/watchlist_test.py
@@ -48,6 +48,19 @@ def test_add_to_watchlist():
 	Watchlist.create_if_not_exist(path)
 	watchlist = Watchlist(path)
 
+	try:
+		watchlist.add_channel()
+	except TypeError:
+		pass
+
+	try:
+		watchlist.add_channel(
+			id = 'UCYO_jab_esuFRV4b17AJtAw',
+			source = 'non-existant',
+		)
+	except ValueError:
+		pass
+
 	watchlist.add_channel(
 		name = '3Blue1Brown',
 		id = 'UCYO_jab_esuFRV4b17AJtAw',
@@ -94,6 +107,11 @@ def test_remove_from_watchlist():
 		os.remove(path)
 	Watchlist.create_if_not_exist(path)
 	watchlist = Watchlist(path)
+
+	try:
+		watchlist.remove_channel()
+	except TypeError:
+		pass
 
 	watchlist.add_channel(
 		name = '3Blue1Brown',

--- a/server/tests/watchlist_test.py
+++ b/server/tests/watchlist_test.py
@@ -87,3 +87,57 @@ def test_add_to_watchlist():
 		},
 	]
 	os.remove(path)
+
+def test_remove_from_watchlist():
+	path = 'tests/testdir/test_remove_from_watchlist.ini'
+	if os.path.exists(path):
+		os.remove(path)
+	Watchlist.create_if_not_exist(path)
+	watchlist = Watchlist(path)
+
+	watchlist.add_channel(
+		name = '3Blue1Brown',
+		id = 'UCYO_jab_esuFRV4b17AJtAw',
+	)
+
+	assert watchlist.remove_channel(
+		id = 'UCBR8-60-B28hp2BmDPdntcQ',
+	)
+	assert not watchlist.remove_channel(
+		id = 'UCBR8-60-B28hp2BmDPdntcQ',
+	)
+	assert watchlist.channels == [
+		{
+			'name': '3Blue1Brown',
+			'id': 'UCYO_jab_esuFRV4b17AJtAw',
+			'source': 'youtube',
+			'site': 'www.youtube.com',
+		},
+	]
+
+	watchlist.add_channel(
+		name = '3Blue1Brown',
+		id = 'UCYO_jab_esuFRV4b17AJtAw',
+		source = 'invidious',
+		site = 'vid.puffyan.us',
+	)
+
+	assert watchlist.remove_channel(
+		id = 'UCYO_jab_esuFRV4b17AJtAw',
+		source = 'Youtube',
+	)
+	assert not watchlist.remove_channel(
+		id = 'UCYO_jab_esuFRV4b17AJtAw',
+		source = 'Youtube',
+	)
+	watchlist.write()
+	read_list = Watchlist(path)
+	assert read_list.channels == [
+		{
+			'name': '3Blue1Brown',
+			'id': 'UCYO_jab_esuFRV4b17AJtAw',
+			'source': 'invidious',
+			'site': 'vid.puffyan.us',
+		},
+	]
+	os.remove(path)

--- a/server/tests/watchlist_test.py
+++ b/server/tests/watchlist_test.py
@@ -28,10 +28,11 @@ def test_create_if_not_exist():
 
 def test_borked_watchlist(borked_watchlist):
 	# only one valid entry
-	assert borked_watchlist.channels == [
+	print(list(borked_watchlist))
+	assert list(borked_watchlist) == [
 		{
-			'name': 'Fireship',
 			'id': 'UCsBjURrPoezykLs9EqgamOA',
+			'name': 'Fireship',
 			'source': 'youtube',
 			'site': 'www.youtube.com',
 		}
@@ -65,21 +66,21 @@ def test_add_to_watchlist():
 		name = '3Blue1Brown',
 		id = 'UCYO_jab_esuFRV4b17AJtAw',
 	)
-	assert watchlist.channels[-1]['source'] == 'youtube'
-	assert watchlist.channels[-1]['site'] == 'www.youtube.com'
+	assert list(watchlist)[-1]['source'] == 'youtube'
+	assert list(watchlist)[-1]['site'] == 'www.youtube.com'
 
 	watchlist.add_channel(
 		name = 'Fireship',
 		id = 'UCsBjURrPoezykLs9EqgamOA',
 		source = 'Invidious',
 	)
-	assert watchlist.channels[-1]['source'] == 'invidious'
-	assert watchlist.channels[-1]['site'] == 'vid.puffyan.us'
+	assert list(watchlist)[-1]['source'] == 'invidious'
+	assert list(watchlist)[-1]['site'] == 'vid.puffyan.us'
 
 	watchlist.write()
 
 	read_list = Watchlist(path)
-	assert read_list.channels == [
+	assert list(read_list) == [
 		{
 			'name': 'Youtube',
 			'id': 'UCBR8-60-B28hp2BmDPdntcQ',
@@ -108,23 +109,14 @@ def test_remove_from_watchlist():
 	Watchlist.create_if_not_exist(path)
 	watchlist = Watchlist(path)
 
-	try:
-		watchlist.remove_channel()
-	except TypeError:
-		pass
-
 	watchlist.add_channel(
 		name = '3Blue1Brown',
 		id = 'UCYO_jab_esuFRV4b17AJtAw',
 	)
 
-	assert watchlist.remove_channel(
-		id = 'UCBR8-60-B28hp2BmDPdntcQ',
-	)
-	assert not watchlist.remove_channel(
-		id = 'UCBR8-60-B28hp2BmDPdntcQ',
-	)
-	assert watchlist.channels == [
+	assert watchlist.remove_channel('UCBR8-60-B28hp2BmDPdntcQ')
+	assert not watchlist.remove_channel('UCBR8-60-B28hp2BmDPdntcQ')
+	assert list(watchlist) == [
 		{
 			'name': '3Blue1Brown',
 			'id': 'UCYO_jab_esuFRV4b17AJtAw',
@@ -140,22 +132,8 @@ def test_remove_from_watchlist():
 		site = 'vid.puffyan.us',
 	)
 
-	assert watchlist.remove_channel(
-		id = 'UCYO_jab_esuFRV4b17AJtAw',
-		source = 'Youtube',
-	)
-	assert not watchlist.remove_channel(
-		id = 'UCYO_jab_esuFRV4b17AJtAw',
-		source = 'Youtube',
-	)
+	assert watchlist.remove_channel('UCYO_jab_esuFRV4b17AJtAw')
 	watchlist.write()
 	read_list = Watchlist(path)
-	assert read_list.channels == [
-		{
-			'name': '3Blue1Brown',
-			'id': 'UCYO_jab_esuFRV4b17AJtAw',
-			'source': 'invidious',
-			'site': 'vid.puffyan.us',
-		},
-	]
+	assert list(read_list) == []
 	os.remove(path)

--- a/server/watchlist.ini
+++ b/server/watchlist.ini
@@ -11,11 +11,11 @@
 ; elif source == 'invidious':
 ;     site = vid.puffyan.us
 
-[Youtube]
-id = UCBR8-60-B28hp2BmDPdntcQ
+[UCBR8-60-B28hp2BmDPdntcQ]
+name = Youtube
 
-[Fireship]
-id = UCsBjURrPoezykLs9EqgamOA
+[UCsBjURrPoezykLs9EqgamOA]
+name = Fireship
 
-[3Blue1Brown]
-id = UCYO_jab_esuFRV4b17AJtAw
+[UCYO_jab_esuFRV4b17AJtAw]
+name = 3Blue1Brown


### PR DESCRIPTION
Latest commit message

API:
	Only the "id" field is mandatory.
	Other fields are optional.
	Default values are for Youtube, not invidious.
	As of now, frontend only needs to test Youtube as a source

	The "name" field currently is only for internal use

	POST/DELETE /watchlist
		json = {
			"id": <channel_id>,
			"source": ("youtube"|"invidious"),
			"site": <url>,
			"name": <name>,
		}

I'll do the API doc later.
The only field that frontend has to be concerned with right now is just "Id".
The other fields are provided only because they are the accepted fields in the a watchlist file.

Reminder: "Content-Type" in the header has to be set to "application/json" for flask to recognize it as json.