### PR TITLE
Mutate watchlist

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,3 +1,4 @@
 /virtualenv/
 /.pytest_cache/
 .coverage
+/downloadedvideos

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -26,9 +26,9 @@ def add_routes(app):
 		# only required value is 'id'
 		json = request.get_json()
 		if 'id' not in json and 'url' not in json:
-			return '', 400 # bad request
+			return 'requires the fields "id" or "url" to specify which channel to add', 400 # bad request
 		if 'id' in json and 'url' in json:
-			return '', 400 # bad request
+			return '"id" and "url" are mutually exclusive', 400 # bad request
 
 		args = {}
 		if 'id' in json:
@@ -37,7 +37,7 @@ def add_routes(app):
 			id = await url_to_video_id(json['url'])
 			if id is None: #pragma: nocover
 				# channel id is not found
-				return '', 404 # Not Found
+				return "couldn't extract channel id from url", 404 # Not Found
 			args['id'] = id
 
 		watchlist = Watchlist(app.config['watchlist'])
@@ -52,7 +52,7 @@ def add_routes(app):
 	async def download_video():
 		video_id = request.args.get('videoid')
 		if len(video_id) != 11: # yt vids are 11 chars
-			return '', 400
+			return 'invalid video id', 400
 		ydl_opts = {
 			'format': 'mp4/bestaudio/best',
 			'outtmpl': './downloadedvideos/%(title)s.%(ext)s',

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -25,7 +25,7 @@ def add_routes(app):
 		# only required value is 'id'
 		json = request.get_json()
 		if 'id' not in json:
-			return 'invalid json'
+			return '', 400 # bad request
 		args = {}
 		_copy_values(args, json, ('id', 'source', 'site', 'name'))
 
@@ -35,4 +35,4 @@ def add_routes(app):
 		if request.method == 'DELETE':
 			watchlist.remove_channel(**args)
 		watchlist.write()
-		return 'success'
+		return '', 200 # ok

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -33,6 +33,6 @@ def add_routes(app):
 		if request.method == 'POST':
 			watchlist.add_channel(**args)
 		if request.method == 'DELETE':
-			watchlist.remove_channel(**args)
+			watchlist.remove_channel(args['id'])
 		watchlist.write()
 		return '', 200 # ok

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -52,6 +52,4 @@ def add_routes(app):
 		download_video = DownloadVideo(ydl_opts)
 		download_status = await download_video.download_video(video_id)
 
-		return jsonify(download_status, 200) if download_status == 'DownloadError' else jsonify('', 400)
-
-		
+		return jsonify(download_status, 400) if download_status == 'DownloadError' else jsonify('', 200)

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -1,7 +1,7 @@
 from flask import jsonify, request
 from .watchlist import Watchlist
 from . import rss
-from . import video_download
+from .video_download import DownloadVideo
 
 def _copy_values(target, source, keys):
 	for key in keys:
@@ -39,11 +39,19 @@ def add_routes(app):
 		return '', 200 # ok
 	
 	@app.route('/download-video', methods=['GET', 'POST'])
-	def download_video():
+	async def download_video():
 		video_id = request.args.get('videoid')
 		if len(video_id) != 11: # yt vids are 11 chars
 			return '', 400
-		download_status = video_download.download_video(video_id)
-		if download_status == 'DownloadError':
-			return download_status, 400
-		return '', 200
+    
+		ydl_opts = {
+      'format': 'mp4/bestaudio/best',
+      'outtmpl': './downloadedvideos/%(title)s.%(ext)s',
+    
+		}
+		download_video = DownloadVideo(ydl_opts)
+		download_status = await download_video.download_video(video_id)
+
+		return jsonify(download_status, 200) if download_status == 'DownloadError' else jsonify('', 400)
+
+		

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -1,5 +1,11 @@
-from flask import jsonify
+from flask import jsonify, request
+from .watchlist import Watchlist
 from . import rss
+
+def _copy_values(target, source, keys):
+	for key in keys:
+		if key in source:
+			target[key] = source[key]
 
 def add_routes(app):
 	@app.route('/hello_world')
@@ -13,3 +19,20 @@ def add_routes(app):
 	@app.route('/videos')
 	def videos():
 		return jsonify(rss.summarize_watchlist(app.config['watchlist']))
+
+	@app.route('/watchlist', methods=['POST', 'DELETE'])
+	def modify_watchlist():
+		# only required value is 'id'
+		json = request.get_json()
+		if 'id' not in json:
+			return 'invalid json'
+		args = {}
+		_copy_values(args, json, ('id', 'source', 'site', 'name'))
+
+		watchlist = Watchlist(app.config['watchlist'])
+		if request.method == 'POST':
+			watchlist.add_channel(**args)
+		if request.method == 'DELETE':
+			watchlist.remove_channel(**args)
+		watchlist.write()
+		return 'success'

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -1,6 +1,7 @@
 from flask import jsonify, request
 from .watchlist import Watchlist
 from . import rss
+from . import video_download
 
 def _copy_values(target, source, keys):
 	for key in keys:
@@ -36,3 +37,13 @@ def add_routes(app):
 			watchlist.remove_channel(**args)
 		watchlist.write()
 		return '', 200 # ok
+	
+	@app.route('/download-video', methods=['GET', 'POST'])
+	def download_video():
+		video_id = request.args.get('videoid')
+		if len(video_id) != 11: # yt vids are 11 chars
+			return '', 400
+		download_status = video_download.download_video(video_id)
+		if download_status == 'DownloadError':
+			return download_status, 400
+		return '', 200

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -43,11 +43,9 @@ def add_routes(app):
 		video_id = request.args.get('videoid')
 		if len(video_id) != 11: # yt vids are 11 chars
 			return '', 400
-    
 		ydl_opts = {
-      'format': 'mp4/bestaudio/best',
-      'outtmpl': './downloadedvideos/%(title)s.%(ext)s',
-    
+			'format': 'mp4/bestaudio/best',
+			'outtmpl': './downloadedvideos/%(title)s.%(ext)s',
 		}
 		download_video = DownloadVideo(ydl_opts)
 		download_status = await download_video.download_video(video_id)

--- a/server/app/video_download.py
+++ b/server/app/video_download.py
@@ -3,15 +3,15 @@ from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
 class DownloadVideo:
-  def __init__(self, opts):
-    self.ydl_opts = opts
+	def __init__(self, opts):
+		self.ydl_opts = opts
 
-  async def download_video(self, id):
-    URL = f'https://www.youtube.com/watch?v={id}'
-    ydl_opts = self.ydl_opts
-    with YoutubeDL(ydl_opts) as ydl:
-        try:
-          threading.Thread(target=ydl.download([URL]))
-        except DownloadError:
-          return "DownloadError"
-    return "Done"
+	async def download_video(self, id):
+		URL = f'https://www.youtube.com/watch?v={id}'
+		ydl_opts = self.ydl_opts
+		with YoutubeDL(ydl_opts) as ydl:
+			try:
+				threading.Thread(target=ydl.download([URL]))
+			except DownloadError:
+				return "DownloadError"
+		return "Done"

--- a/server/app/video_download.py
+++ b/server/app/video_download.py
@@ -2,14 +2,16 @@ import threading
 from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
-def download_video(id):
-  URL = f'https://www.youtube.com/watch?v={id}'
-  ydl_opts = {
-    'format': 'mp4/bestaudio/best',
-    'outtmpl': './downloadedvideos/%(title)s.%(ext)s',
-  }
-  with YoutubeDL(ydl_opts) as ydl:
-      try:
-        threading.Thread(target=ydl.download([URL]))
-      except DownloadError:
-        return "DownloadError"
+class DownloadVideo:
+  def __init__(self, opts):
+    self.ydl_opts = opts
+
+  async def download_video(self, id):
+    URL = f'https://www.youtube.com/watch?v={id}'
+    ydl_opts = self.ydl_opts
+    with YoutubeDL(ydl_opts) as ydl:
+        try:
+          threading.Thread(target=ydl.download([URL]))
+        except DownloadError:
+          return "DownloadError"
+    return "Done"

--- a/server/app/video_download.py
+++ b/server/app/video_download.py
@@ -1,4 +1,4 @@
-import threading
+import asyncio
 from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
@@ -11,7 +11,7 @@ class DownloadVideo:
 		ydl_opts = self.ydl_opts
 		with YoutubeDL(ydl_opts) as ydl:
 			try:
-				threading.Thread(target=ydl.download([URL]))
+				await asyncio.to_thread(lambda: ydl.download([URL]))
 			except DownloadError:
 				return "DownloadError"
 		return "Done"

--- a/server/app/video_download.py
+++ b/server/app/video_download.py
@@ -1,0 +1,15 @@
+import threading
+from yt_dlp import YoutubeDL
+from yt_dlp.utils import DownloadError
+
+def download_video(id):
+  URL = f'https://www.youtube.com/watch?v={id}'
+  ydl_opts = {
+    'format': 'mp4/bestaudio/best',
+    'outtmpl': './downloadedvideos/%(title)s.%(ext)s',
+  }
+  with YoutubeDL(ydl_opts) as ydl:
+      try:
+        threading.Thread(target=ydl.download([URL]))
+      except DownloadError:
+        return "DownloadError"

--- a/server/app/video_download.py
+++ b/server/app/video_download.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from yt_dlp import YoutubeDL
 from yt_dlp.utils import DownloadError
 
@@ -15,3 +16,88 @@ class DownloadVideo:
 			except DownloadError:
 				return "DownloadError"
 		return "Done"
+
+class Extractor:
+	def __init__(self, regex, group_names):
+		# group_names are the names of the values returned by
+		# <re.Match>.groups()
+		self.regex = re.compile(regex)
+		self.group_names = group_names
+
+	def match(self, string):
+		result = self.regex.match(string)
+		if not result: return None
+
+		attributes = {}
+		for name, group in zip(self.group_names, result.groups()):
+			if not name: continue
+			attributes[name] = group
+		return attributes
+
+class ChannelUrlMatcher(Extractor):
+	format_string = '{protocol}://{site}/{path}/({target})(/{suffix})?/?'
+	path = 'channel'
+	target_regex = '[a-zA-Z0-9_-]{24}'
+	target_name = 'id'
+
+	def __init__(self, *, protocol='https', site='www.youtube.com', suffix=''):
+		# suffix should not have beginning or ending slashes
+		self.protocol = protocol
+		self.site = site
+		regex = self.format_string.format(
+			protocol=protocol,
+			site=site,
+			path=self.path,
+			target=self.target_regex,
+			suffix=suffix,
+		)
+		super().__init__(regex, (self.target_name, None))
+
+	async def match_async(self, url):
+		return self.match(url)
+
+class ChannelNamedUrlMatcher(ChannelUrlMatcher):
+	path = 'c'
+	target_regex = '[a-zA-Z0-9_-]+'
+	target_name = 'name'
+
+	# This method may make an http(s) request.
+	# Use match_async instead.
+	def match(self, url):
+		result = super().match(url)
+		if not result:
+			return result
+		name = result['name']
+
+		ydl_opts = {
+			'playlist_items': '1', 
+		}
+		with YoutubeDL(ydl_opts) as ydl:
+			url = f'{self.protocol}://{self.site}/{self.path}/{name}/videos'
+			try:
+				info = ydl.extract_info(url, download=False)
+			except DownloadError: #pragma: nocover
+				return None
+			if 'uploader_id' in info:
+				result['id'] = info['uploader_id']
+				return result
+			return None #pragma: nocover
+
+	async def match_async(self, url):
+		return await asyncio.to_thread(lambda: self.match(url))
+
+url_matchers = [
+	ChannelUrlMatcher(),
+	ChannelUrlMatcher(suffix='featured'),
+	ChannelUrlMatcher(suffix='videos'),
+	ChannelNamedUrlMatcher(),
+	ChannelNamedUrlMatcher(suffix='featured'),
+	ChannelNamedUrlMatcher(suffix='videos'),
+]
+
+async def url_to_video_id(url):
+	for matcher in url_matchers:
+		result = await matcher.match_async(url)
+		if not result:
+			continue
+		return result['id']

--- a/server/app/watchlist.py
+++ b/server/app/watchlist.py
@@ -75,6 +75,23 @@ class Watchlist:
 			'site': site,
 		})
 
+	def remove_channel(self, id=None, source=None, site=None, name=None):
+		if id is None:
+			raise TypeError('Missing keyword argument "id", string expected')
+		for i in range(len(self.channels)):
+			channel = self.channels[i]
+			if channel['id'] != id:
+				continue
+			if source is not None and channel['source'] != source.lower():
+				continue
+			if site is not None and channel['site'] != site:
+				continue
+			if name is not None and channel['name'] != name:
+				continue
+			self.channels.pop(i)
+			return True
+		return False
+
 	@staticmethod
 	def write_watchlist(watchlist, path):
 		config = ConfigParser()

--- a/server/app/watchlist.py
+++ b/server/app/watchlist.py
@@ -85,9 +85,9 @@ class Watchlist:
 			if source is not None and channel['source'] != source.lower():
 				continue
 			if site is not None and channel['site'] != site:
-				continue
+				continue #pragma nocover
 			if name is not None and channel['name'] != name:
-				continue
+				continue #pragma nocover
 			self.channels.pop(i)
 			return True
 		return False

--- a/server/app/watchlist.py
+++ b/server/app/watchlist.py
@@ -16,6 +16,7 @@ url_formats = {
 class Watchlist:
 	def __init__(self, file_path):
 		self.__is_invalid = False
+		self.path = file_path
 		parser = ConfigParser()
 		parser.read(file_path)
 		channels = []
@@ -55,6 +56,36 @@ class Watchlist:
 
 	def is_invalid(self):
 		return self.__is_invalid
+
+	def write(self):
+		self.write_watchlist(self, self.path)
+
+	def add_channel(self, id=None, source='youtube', site=None, name='channel'):
+		if id is None:
+			raise TypeError('Missing keyword argument "id", string expected')
+		source = source.lower()
+		if source not in url_formats:
+			raise ValueError('source not in url formats')
+		if site is None:
+			site = url_formats[source]['default_site']
+		self.channels.append({
+			'name': name,
+			'id': id,
+			'source': source,
+			'site': site,
+		})
+
+	@staticmethod
+	def write_watchlist(watchlist, path):
+		config = ConfigParser()
+		for channel in watchlist.channels:
+			config[channel['name']] = {
+				'id': channel['id'],
+				'source': channel['source'],
+				'site': channel['site'],
+			}
+		with open(path, 'w') as file:
+			config.write(file)
 
 	@staticmethod
 	def create_if_not_exist(file_path):

--- a/server/makefile
+++ b/server/makefile
@@ -13,19 +13,19 @@ all: virtualenv
 virtualenv:
 	virtualenv virtualenv
 	. virtualenv/bin/activate
-	pip install flask
+	pip install flask[async]
 	pip install flask-cors
 	pip install pytest
 	pip install coverage
 	pip install feedparser
 	pip install yt-dlp
-	pip install aioflask
 
 purge: clean
 	-rm -r virtualenv
 
 clean:
 	-rm .coverage
+	-rm -r downloadedvideos
 	-find . -path ./virtualenv -prune \
 		-o -type d -name __pycache__ -print \
 		-o -type d -name .pytest_cache -print \

--- a/server/makefile
+++ b/server/makefile
@@ -18,6 +18,7 @@ virtualenv:
 	pip install pytest
 	pip install coverage
 	pip install feedparser
+	pip install yt-dlp
 
 purge: clean
 	-rm -r virtualenv

--- a/server/makefile
+++ b/server/makefile
@@ -19,6 +19,7 @@ virtualenv:
 	pip install coverage
 	pip install feedparser
 	pip install yt-dlp
+	pip install aioflask
 
 purge: clean
 	-rm -r virtualenv

--- a/server/tests/routes_test.py
+++ b/server/tests/routes_test.py
@@ -58,42 +58,36 @@ def test_modify_watchlist():
 	response = client.post('/watchlist', json={
 		'name': '3Blue1Brown',
 	})
-	assert response.data == b''
 	assert response.status == '400 BAD REQUEST'
 
 	response = client.post('/watchlist', json={
 		'id': 'UCYO_jab_esuFRV4b17AJtAw',
 		'name': '3Blue1Brown',
 	})
-	assert response.data == b''
 	assert response.status == '200 OK'
 
 	# add Fireship, default name is channel
 	response = client.post('/watchlist', json={
 		'id': 'UCsBjURrPoezykLs9EqgamOA',
 	})
-	assert response.data == b''
 	assert response.status == '200 OK'
 
 	response = client.post('/watchlist', json={
 		'id': 'UCBR8-60-B28hp2BmDPdntcQ',
 		'name': 'Youtube',
 	})
-	assert response.data == b''
 	assert response.status == '200 OK'
 
 	# delete Youtube
 	response = client.delete('/watchlist', json={
 		'id': 'UCBR8-60-B28hp2BmDPdntcQ',
 	})
-	assert response.data == b''
 	assert response.status == '200 OK'
 
 	# delete 3Blue1Brown
 	response = client.delete('/watchlist', json={
 		'id': 'UCYO_jab_esuFRV4b17AJtAw',
 	})
-	assert response.data == b''
 	assert response.status == '200 OK'
 
 	watchlist = Watchlist(app.config['watchlist'])
@@ -120,7 +114,6 @@ def test_modify_watchlist_by_url():
 		'url': 'https://www.youtube.com/c/3blue1brown/featured',
 		'id': 'UCYO_jab_esuFRV4b17AJtAw',
 	})
-	assert response.data == b''
 	assert response.status == '400 BAD REQUEST'
 
 	response = client.post('/watchlist', json={

--- a/server/tests/routes_test.py
+++ b/server/tests/routes_test.py
@@ -58,37 +58,43 @@ def test_modify_watchlist():
 	response = client.post('/watchlist', json={
 		'name': '3Blue1Brown',
 	})
-	assert response.data == b'invalid json'
+	assert response.data == b''
+	assert response.status == '400 BAD REQUEST'
 
 	response = client.post('/watchlist', json={
 		'id': 'UCYO_jab_esuFRV4b17AJtAw',
 		'name': '3Blue1Brown',
 	})
-	assert response.data == b'success'
+	assert response.data == b''
+	assert response.status == '200 OK'
 
 	# add Fireship, default name is channel
 	response = client.post('/watchlist', json={
 		'id': 'UCsBjURrPoezykLs9EqgamOA',
 	})
-	assert response.data == b'success'
+	assert response.data == b''
+	assert response.status == '200 OK'
 
 	response = client.post('/watchlist', json={
 		'id': 'UCBR8-60-B28hp2BmDPdntcQ',
 		'name': 'Youtube',
 	})
-	assert response.data == b'success'
+	assert response.data == b''
+	assert response.status == '200 OK'
 
 	# delete Youtube
 	response = client.delete('/watchlist', json={
 		'id': 'UCBR8-60-B28hp2BmDPdntcQ',
 	})
-	assert response.data == b'success'
+	assert response.data == b''
+	assert response.status == '200 OK'
 
 	# delete 3Blue1Brown
 	response = client.delete('/watchlist', json={
 		'id': 'UCYO_jab_esuFRV4b17AJtAw',
 	})
-	assert response.data == b'success'
+	assert response.data == b''
+	assert response.status == '200 OK'
 
 	watchlist = Watchlist(app.config['watchlist'])
 	assert watchlist.channels == [

--- a/server/tests/routes_test.py
+++ b/server/tests/routes_test.py
@@ -97,7 +97,7 @@ def test_modify_watchlist():
 	assert response.status == '200 OK'
 
 	watchlist = Watchlist(app.config['watchlist'])
-	assert watchlist.channels == [
+	assert list(watchlist) == [
 		{
 			'name': 'channel',
 			'id': 'UCsBjURrPoezykLs9EqgamOA',

--- a/server/tests/testdata/borked_watchlist.ini
+++ b/server/tests/testdata/borked_watchlist.ini
@@ -14,9 +14,11 @@
 [Youtube]
 source = Youtube
 
-[Fireship]
-id = UCsBjURrPoezykLs9EqgamOA
+[!@#%@!%!@%$@&&#^*#@#asge]
 
-[3Blue1Brown]
-id = UCYO_jab_esuFRV4b17AJtAw
+[UCsBjURrPoezykLs9EqgamOA]
+name = Fireship
+
+[UCYO_jab_esuFRV4b17AJtAw]
+name = 3Blue1Brown
 source = NotExist

--- a/server/tests/testdata/watchlist.ini
+++ b/server/tests/testdata/watchlist.ini
@@ -11,15 +11,15 @@
 ; elif source == 'invidious':
 ;     site = vid.puffyan.us
 
-[Youtube]
-id = UCBR8-60-B28hp2BmDPdntcQ
+[UCBR8-60-B28hp2BmDPdntcQ]
+name = Youtube
 source = Youtube
 
-[Fireship]
-id = UCsBjURrPoezykLs9EqgamOA
+[UCsBjURrPoezykLs9EqgamOA]
+name = Fireship
 source = Invidious
 
-[3Blue1Brown]
-id = UCYO_jab_esuFRV4b17AJtAw
+[UCYO_jab_esuFRV4b17AJtAw]
+name = 3Blue1Brown
 source = Invidious
 site = inv.riverside.rocks

--- a/server/tests/video_download_test.py
+++ b/server/tests/video_download_test.py
@@ -1,0 +1,32 @@
+import asyncio
+import os
+import pytest
+from app.video_download import url_to_video_id
+
+url_to_video_id_params = [
+	( 'UCBR8-60-B28hp2BmDPdntcQ', 'youtube'  ),
+	( 'UCsBjURrPoezykLs9EqgamOA', 'Fireship' ),
+	( 'UCYO_jab_esuFRV4b17AJtAw', '3blue1brown' ),
+]
+
+@pytest.mark.parametrize('id, name', url_to_video_id_params)
+def test_url_to_video_id(id, name):
+	urls_fetch = [
+		f'https://www.youtube.com/c/{name}',
+		f'https://www.youtube.com/c/{name}/featured',
+		f'https://www.youtube.com/c/{name}/videos',
+	]
+	urls_no_fetch = [
+		f'https://www.youtube.com/channel/{id}',
+		f'https://www.youtube.com/channel/{id}/featured',
+		f'https://www.youtube.com/channel/{id}/videos',
+	]
+	if os.getenv('FETCH_TEST') == 'true':
+		for url in urls_fetch:
+			assert asyncio.run(url_to_video_id(url)) == id
+
+	for url in urls_no_fetch:
+		assert asyncio.run(url_to_video_id(url)) == id
+
+def test_fail_url_to_video_id():
+	assert asyncio.run(url_to_video_id('not an url')) is None

--- a/server/tests/watchlist_test.py
+++ b/server/tests/watchlist_test.py
@@ -40,3 +40,50 @@ def test_borked_watchlist(borked_watchlist):
 def test_is_invalid(watchlist, borked_watchlist):
 	assert watchlist.is_invalid() is False
 	assert borked_watchlist.is_invalid() is True
+
+def test_add_to_watchlist():
+	path = 'tests/testdir/test_add_to_watchlist.ini'
+	if os.path.exists(path):
+		os.remove(path)
+	Watchlist.create_if_not_exist(path)
+	watchlist = Watchlist(path)
+
+	watchlist.add_channel(
+		name = '3Blue1Brown',
+		id = 'UCYO_jab_esuFRV4b17AJtAw',
+	)
+	assert watchlist.channels[-1]['source'] == 'youtube'
+	assert watchlist.channels[-1]['site'] == 'www.youtube.com'
+
+	watchlist.add_channel(
+		name = 'Fireship',
+		id = 'UCsBjURrPoezykLs9EqgamOA',
+		source = 'Invidious',
+	)
+	assert watchlist.channels[-1]['source'] == 'invidious'
+	assert watchlist.channels[-1]['site'] == 'vid.puffyan.us'
+
+	watchlist.write()
+
+	read_list = Watchlist(path)
+	assert read_list.channels == [
+		{
+			'name': 'Youtube',
+			'id': 'UCBR8-60-B28hp2BmDPdntcQ',
+			'source': 'youtube',
+			'site': 'www.youtube.com',
+		},
+		{
+			'name': '3Blue1Brown',
+			'id': 'UCYO_jab_esuFRV4b17AJtAw',
+			'source': 'youtube',
+			'site': 'www.youtube.com',
+		},
+		{
+			'name': 'Fireship',
+			'id': 'UCsBjURrPoezykLs9EqgamOA',
+			'source': 'invidious',
+			'site': 'vid.puffyan.us',
+		},
+	]
+	os.remove(path)

--- a/server/tests/watchlist_test.py
+++ b/server/tests/watchlist_test.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 from app.watchlist import Watchlist
 
 def test_watchlist(watchlist):

--- a/server/tests/watchlist_test.py
+++ b/server/tests/watchlist_test.py
@@ -28,7 +28,6 @@ def test_create_if_not_exist():
 
 def test_borked_watchlist(borked_watchlist):
 	# only one valid entry
-	print(list(borked_watchlist))
 	assert list(borked_watchlist) == [
 		{
 			'id': 'UCsBjURrPoezykLs9EqgamOA',

--- a/server/tests/watchlist_test.py
+++ b/server/tests/watchlist_test.py
@@ -11,7 +11,7 @@ def test_watchlist(watchlist):
 	assert correct_list == list(map(lambda x: x['id'], watchlist))
 
 def test_create_if_not_exist():
-	path = 'tests/testdir/watchlist'
+	path = 'tests/testdir/watchlist.ini'
 	if os.path.exists(path):
 		if os.path.isdir(path):
 			os.rmdir(path)

--- a/server/tests/watchlist_test.py
+++ b/server/tests/watchlist_test.py
@@ -48,6 +48,19 @@ def test_add_to_watchlist():
 	Watchlist.create_if_not_exist(path)
 	watchlist = Watchlist(path)
 
+	try:
+		watchlist.add_channel()
+	except TypeError:
+		pass
+
+	try:
+		watchlist.add_channel(
+			id = 'UCYO_jab_esuFRV4b17AJtAw',
+			source = 'non-existant',
+		)
+	except ValueError:
+		pass
+
 	watchlist.add_channel(
 		name = '3Blue1Brown',
 		id = 'UCYO_jab_esuFRV4b17AJtAw',
@@ -94,6 +107,11 @@ def test_remove_from_watchlist():
 		os.remove(path)
 	Watchlist.create_if_not_exist(path)
 	watchlist = Watchlist(path)
+
+	try:
+		watchlist.remove_channel()
+	except TypeError:
+		pass
 
 	watchlist.add_channel(
 		name = '3Blue1Brown',

--- a/server/tests/watchlist_test.py
+++ b/server/tests/watchlist_test.py
@@ -87,3 +87,57 @@ def test_add_to_watchlist():
 		},
 	]
 	os.remove(path)
+
+def test_remove_from_watchlist():
+	path = 'tests/testdir/test_remove_from_watchlist.ini'
+	if os.path.exists(path):
+		os.remove(path)
+	Watchlist.create_if_not_exist(path)
+	watchlist = Watchlist(path)
+
+	watchlist.add_channel(
+		name = '3Blue1Brown',
+		id = 'UCYO_jab_esuFRV4b17AJtAw',
+	)
+
+	assert watchlist.remove_channel(
+		id = 'UCBR8-60-B28hp2BmDPdntcQ',
+	)
+	assert not watchlist.remove_channel(
+		id = 'UCBR8-60-B28hp2BmDPdntcQ',
+	)
+	assert watchlist.channels == [
+		{
+			'name': '3Blue1Brown',
+			'id': 'UCYO_jab_esuFRV4b17AJtAw',
+			'source': 'youtube',
+			'site': 'www.youtube.com',
+		},
+	]
+
+	watchlist.add_channel(
+		name = '3Blue1Brown',
+		id = 'UCYO_jab_esuFRV4b17AJtAw',
+		source = 'invidious',
+		site = 'vid.puffyan.us',
+	)
+
+	assert watchlist.remove_channel(
+		id = 'UCYO_jab_esuFRV4b17AJtAw',
+		source = 'Youtube',
+	)
+	assert not watchlist.remove_channel(
+		id = 'UCYO_jab_esuFRV4b17AJtAw',
+		source = 'Youtube',
+	)
+	watchlist.write()
+	read_list = Watchlist(path)
+	assert read_list.channels == [
+		{
+			'name': '3Blue1Brown',
+			'id': 'UCYO_jab_esuFRV4b17AJtAw',
+			'source': 'invidious',
+			'site': 'vid.puffyan.us',
+		},
+	]
+	os.remove(path)

--- a/server/tests/watchlist_test.py
+++ b/server/tests/watchlist_test.py
@@ -28,10 +28,11 @@ def test_create_if_not_exist():
 
 def test_borked_watchlist(borked_watchlist):
 	# only one valid entry
-	assert borked_watchlist.channels == [
+	print(list(borked_watchlist))
+	assert list(borked_watchlist) == [
 		{
-			'name': 'Fireship',
 			'id': 'UCsBjURrPoezykLs9EqgamOA',
+			'name': 'Fireship',
 			'source': 'youtube',
 			'site': 'www.youtube.com',
 		}
@@ -65,21 +66,21 @@ def test_add_to_watchlist():
 		name = '3Blue1Brown',
 		id = 'UCYO_jab_esuFRV4b17AJtAw',
 	)
-	assert watchlist.channels[-1]['source'] == 'youtube'
-	assert watchlist.channels[-1]['site'] == 'www.youtube.com'
+	assert list(watchlist)[-1]['source'] == 'youtube'
+	assert list(watchlist)[-1]['site'] == 'www.youtube.com'
 
 	watchlist.add_channel(
 		name = 'Fireship',
 		id = 'UCsBjURrPoezykLs9EqgamOA',
 		source = 'Invidious',
 	)
-	assert watchlist.channels[-1]['source'] == 'invidious'
-	assert watchlist.channels[-1]['site'] == 'vid.puffyan.us'
+	assert list(watchlist)[-1]['source'] == 'invidious'
+	assert list(watchlist)[-1]['site'] == 'vid.puffyan.us'
 
 	watchlist.write()
 
 	read_list = Watchlist(path)
-	assert read_list.channels == [
+	assert list(read_list) == [
 		{
 			'name': 'Youtube',
 			'id': 'UCBR8-60-B28hp2BmDPdntcQ',
@@ -108,23 +109,14 @@ def test_remove_from_watchlist():
 	Watchlist.create_if_not_exist(path)
 	watchlist = Watchlist(path)
 
-	try:
-		watchlist.remove_channel()
-	except TypeError:
-		pass
-
 	watchlist.add_channel(
 		name = '3Blue1Brown',
 		id = 'UCYO_jab_esuFRV4b17AJtAw',
 	)
 
-	assert watchlist.remove_channel(
-		id = 'UCBR8-60-B28hp2BmDPdntcQ',
-	)
-	assert not watchlist.remove_channel(
-		id = 'UCBR8-60-B28hp2BmDPdntcQ',
-	)
-	assert watchlist.channels == [
+	assert watchlist.remove_channel('UCBR8-60-B28hp2BmDPdntcQ')
+	assert not watchlist.remove_channel('UCBR8-60-B28hp2BmDPdntcQ')
+	assert list(watchlist) == [
 		{
 			'name': '3Blue1Brown',
 			'id': 'UCYO_jab_esuFRV4b17AJtAw',
@@ -140,22 +132,8 @@ def test_remove_from_watchlist():
 		site = 'vid.puffyan.us',
 	)
 
-	assert watchlist.remove_channel(
-		id = 'UCYO_jab_esuFRV4b17AJtAw',
-		source = 'Youtube',
-	)
-	assert not watchlist.remove_channel(
-		id = 'UCYO_jab_esuFRV4b17AJtAw',
-		source = 'Youtube',
-	)
+	assert watchlist.remove_channel('UCYO_jab_esuFRV4b17AJtAw')
 	watchlist.write()
 	read_list = Watchlist(path)
-	assert read_list.channels == [
-		{
-			'name': '3Blue1Brown',
-			'id': 'UCYO_jab_esuFRV4b17AJtAw',
-			'source': 'invidious',
-			'site': 'vid.puffyan.us',
-		},
-	]
+	assert list(read_list) == []
 	os.remove(path)

--- a/server/watchlist.ini
+++ b/server/watchlist.ini
@@ -11,11 +11,11 @@
 ; elif source == 'invidious':
 ;     site = vid.puffyan.us
 
-[Youtube]
-id = UCBR8-60-B28hp2BmDPdntcQ
+[UCBR8-60-B28hp2BmDPdntcQ]
+name = Youtube
 
-[Fireship]
-id = UCsBjURrPoezykLs9EqgamOA
+[UCsBjURrPoezykLs9EqgamOA]
+name = Fireship
 
-[3Blue1Brown]
-id = UCYO_jab_esuFRV4b17AJtAw
+[UCYO_jab_esuFRV4b17AJtAw]
+name = 3Blue1Brown


### PR DESCRIPTION
Add option to add/remove watchlist entries using urls

API update:
    /watchlist POST/DELETE {'url': <channel_url>}

The previous option to use channel id to add/delete is still available.
    /watchlist POST/DELETE {'id': <channel_id>}

Python dependencies have changed to add flask async routes, please rebuild your virtualenv.

The options 'site' and 'source' for /watchlist POST/DELETE will no longer be supported.
However I have not removed them yet as of now (mainly due to not wanting to rewrite some tests yet), but will soon.